### PR TITLE
add: action workflows

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -1,0 +1,25 @@
+name: Cargo Build & Test
+
+on:
+  push:
+  pull_request:
+
+env: 
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_and_test:
+    name: Rust project - latest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - stable
+          - beta
+          - nightly
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: cargo build --verbose
+      - run: cargo test --verbose
+  

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -14,12 +14,10 @@ jobs:
     strategy:
       matrix:
         toolchain:
-          - stable
-          - beta
           - nightly
     steps:
       - uses: actions/checkout@v4
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
-      - run: cargo build --verbose
+      - run: cargo build-kernel
       - run: cargo test --verbose
   

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: rustup component add rust-src
       - run: cargo build-kernel
       - run: cargo test --verbose
   

--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -1,4 +1,4 @@
-name: Cargo Build & Test
+name: cargo build-kernel && cargo test
 
 on:
   push:

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,0 +1,24 @@
+name: Cargo Build & Test
+
+on:
+  push:
+  pull_request:
+
+env: 
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_and_test:
+    name: Rust project - latest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - nightly
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup update ${{ matrix.toolchain }} && rustup default ${{ matrix.toolchain }}
+      - run: rustup component add rust-src
+      - run: rustup component add clippy
+      - run: cargo build-kernel
+      - run: cargo clippy -- -D warnings

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -1,4 +1,4 @@
-name: Cargo Build & Test
+name: cargo clippy -- -D warnings
 
 on:
   push:

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -11,10 +11,6 @@ jobs:
   build_and_test:
     name: Rust project - latest
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toolchain:
-          - nightly
     steps:
       - uses: actions/checkout@v4
       - run: rustup component add rustfmt

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,4 +1,4 @@
-name: rustfmt
+name: cargo fmt -- --check
 
 on:
   push:
@@ -14,4 +14,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: rustup component add rustfmt
-      - run: rustfmt --check src/**/*.rs
+      - run: cargo fmt -- --check

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,4 +1,4 @@
-name: Cargo Build & Test
+name: rustfmt
 
 on:
   push:

--- a/.github/workflows/rustfmt.yml
+++ b/.github/workflows/rustfmt.yml
@@ -1,0 +1,21 @@
+name: Cargo Build & Test
+
+on:
+  push:
+  pull_request:
+
+env: 
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build_and_test:
+    name: Rust project - latest
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+          - nightly
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup component add rustfmt
+      - run: rustfmt --check src/**/*.rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,9 @@ edition = "2021"
 
 [lib]
 crate-type = ["staticlib"]
+
+[profile.dev]
+panic = "abort"
+
+[profile.release]
+panic = "abort"

--- a/src/gdt/access.rs
+++ b/src/gdt/access.rs
@@ -88,7 +88,7 @@ impl Access {
         result |= (self.e as u8) << 3;
         result |= (self.dc as u8) << 2;
         result |= (self.rw as u8) << 1;
-        result |= (self.a as u8) << 0;
+        result |= (self.a as u8);
 
         result
     }

--- a/src/gdt/access.rs
+++ b/src/gdt/access.rs
@@ -1,52 +1,51 @@
-#[derive(PartialEq,Clone, Copy)]
-#[repr(u8)]            
+#[derive(PartialEq, Clone, Copy)]
+#[repr(u8)]
 pub enum Presence {
     Invalid = 0,
-    Valid = 1
+    Valid = 1,
 }
 
-#[derive(PartialEq,Clone, Copy)]
-#[repr(u8)]            
+#[derive(PartialEq, Clone, Copy)]
+#[repr(u8)]
 pub enum DescriptorPriviledgeLevel {
     Lvl0 = 0,
     Lvl1 = 1,
     Lvl2 = 2,
     Lvl3 = 3,
 }
-#[derive(PartialEq,Clone, Copy)]
-#[repr(u8)]            
+#[derive(PartialEq, Clone, Copy)]
+#[repr(u8)]
 pub enum SegmentType {
     System = 0,
-    CodeOrData = 1
+    CodeOrData = 1,
 }
 
-#[repr(u8)]            
-#[derive(PartialEq,Clone, Copy)]
+#[repr(u8)]
+#[derive(PartialEq, Clone, Copy)]
 pub enum ExecutabilityType {
     Data = 0,
-    Code = 1
+    Code = 1,
 }
 
-
-#[repr(u8)]            
-#[derive(PartialEq,Clone, Copy)]
+#[repr(u8)]
+#[derive(PartialEq, Clone, Copy)]
 pub enum Direction {
     GrowsUp = 0,
-    GrowsDown = 1
+    GrowsDown = 1,
 }
 
-#[repr(u8)]            
-#[derive(PartialEq,Clone, Copy)]
+#[repr(u8)]
+#[derive(PartialEq, Clone, Copy)]
 pub enum ReadWriteAble {
     Clear = 0,
-    Set = 1
+    Set = 1,
 }
 
-#[repr(u8)]            
-#[derive(PartialEq,Clone, Copy)]
+#[repr(u8)]
+#[derive(PartialEq, Clone, Copy)]
 pub enum AccessBit {
     OnlyForSpecial = 0,
-    Default = 1
+    Default = 1,
 }
 
 pub struct Access {
@@ -56,7 +55,7 @@ pub struct Access {
     e: ExecutabilityType,
     dc: Direction,
     rw: ReadWriteAble,
-    a: AccessBit
+    a: AccessBit,
 }
 
 impl Access {

--- a/src/gdt/entry.rs
+++ b/src/gdt/entry.rs
@@ -8,34 +8,41 @@ pub struct Entry {
     access: u8,
     base_16_23: u8,
     base_0_15: u16,
-    limit_0_15: u16
+    limit_0_15: u16,
 }
 
 impl Entry {
     pub fn new(base: u32, limit: u32, flag: Flag, access: Access) -> Self {
-        Entry { 
+        Entry {
             base_31_24: ((base & 0xFF000000) >> 24) as u8,
             flags_limit_16_19: flag.to_u8() | ((limit & 0x000F0000) >> 16) as u8,
             access: access.to_u8(),
             base_16_23: ((base & 0x000F0000) >> 16) as u8,
-            base_0_15: ((base & 0x0000FFFF)) as u16,
-            limit_0_15: ((limit & 0x0000FFFF)) as u16,
+            base_0_15: (base & 0x0000FFFF) as u16,
+            limit_0_15: (limit & 0x0000FFFF) as u16,
         }
     }
     pub fn new_zero() -> Self {
-        Entry { base_31_24: 0, flags_limit_16_19: 0, access: 0, base_16_23: 0, base_0_15: 0, limit_0_15: 0 }
+        Entry {
+            base_31_24: 0,
+            flags_limit_16_19: 0,
+            access: 0,
+            base_16_23: 0,
+            base_0_15: 0,
+            limit_0_15: 0,
+        }
     }
 
     pub fn to_u64(&self) -> u64 {
         let mut result: u64 = 0;
 
         result |= (self.base_31_24 as u64) << 56;
-        result |= (self.flags_limit_16_19 as u64) << 48; 
+        result |= (self.flags_limit_16_19 as u64) << 48;
         result |= (self.access as u64) << 40;
-        result |= (self.base_16_23 as u64) << 32; 
-        result |= (self.base_0_15 as u64) << 16; 
-        result |= self.limit_0_15 as u64; 
+        result |= (self.base_16_23 as u64) << 32;
+        result |= (self.base_0_15 as u64) << 16;
+        result |= self.limit_0_15 as u64;
 
-        result 
+        result
     }
 }

--- a/src/gdt/flag.rs
+++ b/src/gdt/flag.rs
@@ -1,39 +1,44 @@
-#[repr(u8)]            
-#[derive(PartialEq,Clone, Copy)]
+#[repr(u8)]
+#[derive(PartialEq, Clone, Copy)]
 pub enum Granularity {
     SingleByte = 0,
-    PageSize4K = 1
+    PageSize4K = 1,
 }
 
-#[derive(PartialEq,Clone, Copy)]
-#[repr(u8)]            
+#[derive(PartialEq, Clone, Copy)]
+#[repr(u8)]
 pub enum DataProtectionSize {
     Segm16bit = 0,
-    Segm32bit = 1
+    Segm32bit = 1,
 }
 
-#[derive(PartialEq,Clone, Copy)]
-#[repr(u8)]            
+#[derive(PartialEq, Clone, Copy)]
+#[repr(u8)]
 pub enum LongMode {
     Other = 0,
-    Segm64bit = 1
+    Segm64bit = 1,
 }
 
 pub struct Flag {
     granularity: Granularity,
     data_protection_size: DataProtectionSize,
-    long_mode: LongMode
+    long_mode: LongMode,
 }
 
 impl Flag {
-    pub fn new(granularity: Granularity, data_protection_size: DataProtectionSize, long_mode: LongMode) -> Self {
-        if data_protection_size == DataProtectionSize::Segm32bit && long_mode == LongMode::Segm64bit {
+    pub fn new(
+        granularity: Granularity,
+        data_protection_size: DataProtectionSize,
+        long_mode: LongMode,
+    ) -> Self {
+        if data_protection_size == DataProtectionSize::Segm32bit && long_mode == LongMode::Segm64bit
+        {
             panic!("error while creating GDT Flag combination - can't have DataProtectionBit and LongModeBit both set at the same time")
         }
         Flag {
             granularity,
             data_protection_size,
-            long_mode
+            long_mode,
         }
     }
 

--- a/src/gdt/flag.rs
+++ b/src/gdt/flag.rs
@@ -49,7 +49,7 @@ impl Flag {
         flag |= (self.data_protection_size as u8) << 2;
         flag |= (self.long_mode as u8) << 1;
 
-        flag = flag << 4; // Because the lower 4 bits are used by limit
+        flag <<= 4; // Because the lower 4 bits are used by limit
         flag
     }
 }

--- a/src/gdt/mod.rs
+++ b/src/gdt/mod.rs
@@ -1,7 +1,7 @@
+mod access;
 mod entry;
 mod flag;
-mod access;
 
+pub use access::*;
 pub use entry::*;
 pub use flag::*;
-pub use access::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,11 @@
 #![no_std]
 
 #[cfg(test)]
-fn main() { }
+fn main() {}
 
+pub mod gdt;
 pub mod idt;
 pub mod vga;
-pub mod gdt;
 
 use core::{panic::PanicInfo, ptr};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ fn panic(_info: &PanicInfo) -> ! {
 }
 
 #[no_mangle]
+#[allow(clippy::empty_loop)]
 pub extern "C" fn kernel_main() {
     let mut vga_buffer = vga::Buffer::new();
     vga_buffer.clear_screen();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,9 @@ pub extern "C" fn kernel_main() {
     vga_buffer.clear_screen();
     vga_buffer.set_colors(vga::VGAColor::Black, vga::VGAColor::Green);
     vga_buffer.set_foreground_color(vga::VGAColor::Blue);
-    vga_buffer.write_char_at(1,0,b'4');
+    vga_buffer.write_char_at(1, 0, b'4');
     vga_buffer.set_background_color(vga::VGAColor::Red);
-    vga_buffer.write_char_at(2,0,b'4');
+    vga_buffer.write_char_at(2, 0, b'4');
     loop {}
 }
 

--- a/src/vga.rs
+++ b/src/vga.rs
@@ -35,7 +35,7 @@ const VGA_WIDTH: u8 = 80;
 const VGA_HEIGHT: u8 = 25;
 const VGA_BUFFER_ADDR: *mut u16 = 0xB8000 as *mut u16;
 
-pub struct  OutOffBoundsError;
+pub struct OutOffBoundsError;
 
 pub struct Buffer {
     color: u8,
@@ -46,7 +46,7 @@ impl Buffer {
     pub fn new() -> Self {
         let mut buffer = Buffer {
             color: 0,
-            buf: VGA_BUFFER_ADDR
+            buf: VGA_BUFFER_ADDR,
         };
         buffer.set_colors(VGAColor::White, VGAColor::Black);
         buffer
@@ -55,7 +55,7 @@ impl Buffer {
     pub fn set_colors(&mut self, foreground: VGAColor, background: VGAColor) {
         self.color = foreground.to_foreground() | background.to_background()
     }
-    
+
     pub fn set_foreground_color(&mut self, foreground: VGAColor) {
         self.color = self.color & 0xF0;
         self.color |= foreground.to_foreground();
@@ -66,8 +66,12 @@ impl Buffer {
         self.color |= background.to_background();
     }
 
-    pub fn write_char_at(&self, row: u8, column: u8, character: u8) -> Result<(), OutOffBoundsError>  {
-
+    pub fn write_char_at(
+        &self,
+        row: u8,
+        column: u8,
+        character: u8,
+    ) -> Result<(), OutOffBoundsError> {
         if row >= VGA_HEIGHT || column >= VGA_WIDTH {
             return Err(OutOffBoundsError);
         }

--- a/src/vga.rs
+++ b/src/vga.rs
@@ -42,6 +42,12 @@ pub struct Buffer {
     buf: *mut u16,
 }
 
+impl Default for Buffer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Buffer {
     pub fn new() -> Self {
         let mut buffer = Buffer {
@@ -57,12 +63,12 @@ impl Buffer {
     }
 
     pub fn set_foreground_color(&mut self, foreground: VGAColor) {
-        self.color = self.color & 0xF0;
+        self.color &= 0xF0;
         self.color |= foreground.to_foreground();
     }
 
     pub fn set_background_color(&mut self, background: VGAColor) {
-        self.color = self.color & 0x0F;
+        self.color &= 0x0F;
         self.color |= background.to_background();
     }
 


### PR DESCRIPTION
1. `cargo test` -> checks for compilation errors and test failures
2. `cargo clippy -- -D warnings` -> static code analysis
3. `cargo fmt -- --check` -> formatting check

Note that 1 & 2 are dependent on the kernel being runnable (what we fixed with the `#[cfg(test)]` stuff, so we need to merge the changes from 5-add-handle-keyboard-entries-and-print-them for the workflows to work properly